### PR TITLE
Add udev rules for gpio and spi. 

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -5,3 +5,4 @@ kano_peripherals /usr/lib/python2.7/dist-packages/
 
 etc/init.d/kano-peripherals /etc/init.d/
 etc/dbus-1/system-local.conf /etc/dbus-1/
+etc/udev/rules.d /etc/udev/rules.d/

--- a/etc/udev/rules.d/99-comm.rules
+++ b/etc/udev/rules.d/99-comm.rules
@@ -1,0 +1,5 @@
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio; chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio; chown -R root:gpio /sys/devices/platform/soc/*.gpio/gpio && chmod -R 770 /sys/devices/platform/soc/*.gpio/gpio'"
+SUBSYSTEM=="input", GROUP="input", MODE="0660"
+SUBSYSTEM=="i2c-dev", GROUP="i2c", MODE="0660"
+SUBSYSTEM=="spidev", GROUP="spi", MODE="0660"
+SUBSYSTEM=="bcm2835-gpiomem", GROUP="gpio", MODE="0660"


### PR DESCRIPTION
This PR is for https://github.com/KanoComputing/peldins/issues/2209
It adds an udev rules file taken from raspbian which enables access to the gpio and spi devices from users in the appropriate groups.
@skarbat @alex5imon 
