### PR TITLE
Provide synchronization under systemd

### DIFF
--- a/bin/kano-speakerleds
+++ b/bin/kano-speakerleds
@@ -15,7 +15,7 @@ Usage:
     kano-speakerleds detect
     kano-speakerleds notification (start|stop) [<spec>...]
     kano-speakerleds initflow [<duration>] [<cycles>]
-    kano-speakerleds cpu-monitor (start|stop) [<rate>] [--check]
+    kano-speakerleds cpu-monitor (start|stop) [<rate>] [--check] [--retry=<seconds>]
     kano-speakerleds off
     kano-speakerleds manu_test <len1> <len2> <len3>
     kano-speakerleds -h | --help
@@ -68,7 +68,13 @@ def main(args):
                 print '<rate> argument was not specified or not an int number'
                 exit(1)
 
-            speaker_leds.cpu_monitor_start(update_rate, args.get('--check'))
+            try:
+                retry_count = int(args.get('--retry')) if args.get('--retry') else 15
+            except:
+                print '<--retry> argument was not specified or not an int number'
+                exit(1)
+
+            speaker_leds.cpu_monitor_start(update_rate, args.get('--check'), retry_count)
 
         elif args['stop']:
             speaker_leds.cpu_monitor_stop()

--- a/kano_peripherals/speaker_leds/use_cases.py
+++ b/kano_peripherals/speaker_leds/use_cases.py
@@ -61,13 +61,13 @@ def initflow_pattern_start(duration, cycles):
     speakerleds_iface.unlock()
 
 
-def cpu_monitor_start(update_rate, check_settings):
+def cpu_monitor_start(update_rate, check_settings, retry_count):
     if check_settings:
         cpu_monitor_on = _get_cpu_monitor_setting()
         if not cpu_monitor_on:
             return
 
-    speakerleds_iface = high_level.get_speakerleds_interface()
+    speakerleds_iface = high_level.get_speakerleds_interface(retry_count=retry_count)
     if not speakerleds_iface:
         logger.warn('Could not aquire dbus interface for cpu-monitor!')
         return


### PR DESCRIPTION
- speakerleds daemon depends on the board daemon availability
- under systemd both services start in parallel, which causes speakerleds to fail
- fixed by implementing a default retry loop, with a custom timeout through the command line

Addresses this ticket: https://github.com/KanoComputing/peldins/issues/2267 

cc @radujipa 
