### PR TITLE
Add rules for serial port, from raspberrypi-sys-mods.

### DIFF
--- a/etc/udev/rules.d/99-comm.rules
+++ b/etc/udev/rules.d/99-comm.rules
@@ -3,3 +3,25 @@ SUBSYSTEM=="input", GROUP="input", MODE="0660"
 SUBSYSTEM=="i2c-dev", GROUP="i2c", MODE="0660"
 SUBSYSTEM=="spidev", GROUP="spi", MODE="0660"
 SUBSYSTEM=="bcm2835-gpiomem", GROUP="gpio", MODE="0660"
+
+KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
+	ALIASES=/proc/device-tree/aliases; \
+	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+		echo 0;\
+	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+		echo 1; \
+	else \
+		exit 1; \
+	fi\
+'", SYMLINK+="serial%c"
+
+KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
+	ALIASES=/proc/device-tree/aliases; \
+	if cmp -s $ALIASES/uart1 $ALIASES/serial0; then \
+		echo 0; \
+	elif cmp -s $ALIASES/uart1 $ALIASES/serial1; then \
+		echo 1; \
+	else \
+		exit 1; \
+	fi \
+'", SYMLINK+="serial%c"


### PR DESCRIPTION
For https://github.com/KanoComputing/peldins/issues/2425
The raspberrypi people decided to rename the serial port, which afffected bluetooth. There are some new
udev rules taken from their raspberrypi-sys-mods package which shoudl fix this.
@alex5imon @skarbat 
