### PR TITLE
Reduce CPU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-peripherals (3.4.0-0) unstable; urgency=low
+
+  * Added is_speaker_plugged api to daemon
+
+ -- Team Kano <dev@kano.me>  Mon, 11 Jan 2016 12:00:00 +0000
+
 kano-peripherals (2.3.0-0) unstable; urgency=low
 
   * Added LED Speaker daemon.

--- a/kano_peripherals/speaker_leds/driver/service.py
+++ b/kano_peripherals/speaker_leds/driver/service.py
@@ -95,6 +95,10 @@ class SpeakerLEDsService(dbus.service.Object):
 
         return True  # keep calling this method indefinitely
 
+    @dbus.service.method(SPEAKER_LEDS_IFACE, in_signature='', out_signature='b')
+    def is_speaker_plugged(self):
+        return self.is_plugged
+
     def _locking_thread(self):
         """
         Check if the locking processes are still alive.

--- a/kano_peripherals/speaker_leds/use_cases.py
+++ b/kano_peripherals/speaker_leds/use_cases.py
@@ -83,15 +83,20 @@ def cpu_monitor_start(update_rate, check_settings, retry_count):
     duration = update_rate
     cycles = duration / 2
 
+    speakerleds_iface = high_level.get_speakerleds_interface()
+
     while not high_level.interrupted:
-        led_speeds = _get_cpu_led_speeds(0.1, num_leds)
+        if speakerleds_iface.is_speaker_plugged():
+            
+            led_speeds = _get_cpu_led_speeds(0.1, num_leds)
 
-        vf2 = high_level.pulse_each(vf, led_speeds)
-        successful = high_level.animate(vf2, duration, cycles)
+            vf2 = high_level.pulse_each(vf, led_speeds)
+            successful = high_level.animate(vf2, duration, cycles)
 
-        if not successful:
+            if not successful:
+                time.sleep(duration)
+        else:
             time.sleep(duration)
-
 
 def cpu_monitor_stop():
     _stop('cpu-monitor')


### PR DESCRIPTION
This PR adds an is_speaker_plugged API to daemon, allowing clients to know if the speaker is there, and changes cpu_monitor not to poll processes when speaker is not present, to reduce cpu usage.

For https://github.com/KanoComputing/peldins/issues/2419 
@radujipa @alex5imon 
