### PR TITLE
Fixing battery systemd unit startup

### DIFF
--- a/debian/kano-peripherals.postinst
+++ b/debian/kano-peripherals.postinst
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# kano-peripherals.postinst
+#
+# Copyright (C) 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+#
+
+case "$1" in
+    configure)
+
+        # Enable the battery bootup service
+        systemctl enable kano-bootup-battery
+        ;;
+esac

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,3 @@ override_dh_auto_build:
 override_dh_fixperms:
 	dh_fixperms
 	chmod 0440 etc/sudoers.d/*
-
-override_dh_systemd_enable:
-	dh_systemd_enable --package=kano-peripherals kano-boards.service
-	dh_systemd_enable --package=kano-peripherals kano-speakerleds.service
-	dh_systemd_enable --package=kano-peripherals kano-bootup-battery.service


### PR DESCRIPTION
The battery systemd unit file was not starting automatically on boot. Fixed by moving the enablement to a postinst file.

Additionally, removed dh_systemd calls, as they are for user units, which are started through dependencies. But I think I am missing something here.. @radujipa 
