### PR TITLE
Fixes a mismatched import path for Tracking

### DIFF
--- a/kano_peripherals/ck2_pro_hat/driver/battery_notify_thread.py
+++ b/kano_peripherals/ck2_pro_hat/driver/battery_notify_thread.py
@@ -13,7 +13,7 @@ from gi.repository import GLib
 from kano.notifications import display_generic_notification, \
     close_current_notification, update_current_notification
 
-from kano_profile.tracker import generate_event
+from kano_profile.tracking_events import generate_event
 
 
 SHUTDOWN_WARN_TIME = 5 * 60  # seconds


### PR DESCRIPTION
This traceback caused `systemd` to complain about starting up, with `rc=1`.
Merging right away, @tombettany @radujipa 
