### PR TITLE
[OS-306] Fix touchscreen hotplug

### DIFF
--- a/conf/xorg.conf.d/80-kano-touch.conf
+++ b/conf/xorg.conf.d/80-kano-touch.conf
@@ -1,0 +1,6 @@
+Section "InputClass"
+    Identifier "ILITEK"
+    Driver "libinput"
+    Option "CalibrationMatrix" "-1.0 0.0 1.0 0.0 -1.0 1.0 0 0 1"
+EndSection
+

--- a/debian/kano-touch-support.install
+++ b/debian/kano-touch-support.install
@@ -1,2 +1,3 @@
 touch-detect/touch-detect usr/bin/
 touch-detect/*.sh  usr/share/kano-peripherals/scripts/
+conf/xorg.conf.d/* usr/share/kano-peripherals/xorg.conf.d/

--- a/debian/kano-touch-support.postinst
+++ b/debian/kano-touch-support.postinst
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# kano-peripherals.postinst
+#
+# Copyright (C) 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+#
+# Post debian package install script
+
+
+case "$1" in
+    configure)
+        # Enable systemd services
+        systemctl enable kano-touch-flip-xorg.service
+        ;;
+esac

--- a/systemd/system/kano-touch-flip-xorg.service
+++ b/systemd/system/kano-touch-flip-xorg.service
@@ -1,0 +1,21 @@
+#
+# kano-touch-flip-xorg.service
+#
+# This service installs or removes the Xorg
+# config to specify the current touch orientation
+
+[Unit]
+Description=Kano Xorg Touch Config
+DefaultDependencies=no
+
+Wants=local-fs-pre.target
+Before=lightdm.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/share/kano-peripherals/scripts/flip_xorg.sh
+
+[Install]
+WantedBy=lightdm.service
+

--- a/touch-detect/rotate_fns.sh
+++ b/touch-detect/rotate_fns.sh
@@ -20,10 +20,9 @@ function exitStatus {
 
 function setXorgRotation {
     if exitStatus $1 ; then
-       TOUCH_DEVICES=$(touch-detect)
-       for device in $TOUCH_DEVICES; do
-           xinput set-prop $device 'libinput Calibration Matrix' -1.0 0.0 1.0 0.0 -1.0 1.0 0 0 1
-       done
+       ln -s /usr/share/kano-peripherals/xorg.conf.d/80-kano-touch.conf /usr/share/X11/xorg.conf.d/
+    else
+       rm /usr/share/X11/xorg.conf.d/80-kano-touch.conf
     fi
 }
 

--- a/touch-detect/set_rotate.sh
+++ b/touch-detect/set_rotate.sh
@@ -8,6 +8,5 @@
 .  /usr/share/kano-peripherals/scripts/rotate_fns.sh
 
 is_rotated; IS_ROTATED=$?
-setXorgRotation $IS_ROTATED
 setQtRotation  $IS_ROTATED
 exportQtRotation


### PR DESCRIPTION
This PR changes Xorg flipping to use an Xorg configuration file, instead of xprop. This makes it robust to unplugging.
For flipping to work properly this config file needs to be present in one mode and not the other. Therefore I have made it a symlink.
However it does mean that the config file is now specific to the ILITEK touchscreen, and will need updating if we ship new ones later.

This will need QA though overture  - it shouldn't affect it, as that's Qt, but you never know.
